### PR TITLE
fix: bug#24 버그 해결

### DIFF
--- a/scripts/initEventListeners.js
+++ b/scripts/initEventListeners.js
@@ -20,8 +20,26 @@ document.addEventListener("DOMContentLoaded", () => {
 const initBackLogEvents = ({ finishDateContent, backLogTaskContent, backLogContainer, editBtn, deleteBtn, dropdownOptions, selected, label, items }) => {
   const state = { editing: false, title: false, date: false };
 
+  // 외부 클릭 감지만 따로 처리
+  handleOutsideClick(state, finishDateContent, backLogTaskContent);
+
+  editBtnEvent({ state, finishDateContent, backLogTaskContent, editBtn, items });
+  deleteBtnEvent({ backLogContainer, deleteBtn, items });
+  selectedEvent({ state, selected, dropdownOptions, label, items });
+  arrowEvent({ backLogContainer, items });
+  searchBtnEvent();
+};
+
+// 백로그 외부 클릭 감지 함수
+const handleOutsideClick = (state, finishDateContent, backLogTaskContent) => {
   document.addEventListener("click", (e) => {
-    if ((state.editing && !backLogContainer.contains(e.target)) || (state.title && state.date)) {
+    const allTaskContainers = document.querySelectorAll(".taskContainer");
+
+    const clickedInsideAny = Array.from(allTaskContainers).some(container =>
+      container.contains(e.target)
+    );
+
+    if ((state.editing && !clickedInsideAny) || (state.title && state.date)) {
       finishDateContent.disabled = true;
       backLogTaskContent.disabled = true;
       state.editing = false;
@@ -32,12 +50,6 @@ const initBackLogEvents = ({ finishDateContent, backLogTaskContent, backLogConta
       renderInitialSubTasks();
     }
   });
-
-  editBtnEvent({ state, finishDateContent, backLogTaskContent, editBtn, items });
-  deleteBtnEvent({ backLogContainer, deleteBtn, items });
-  selectedEvent({ state, selected, dropdownOptions, label, items });
-  arrowEvent({ backLogContainer, items });
-  searchBtnEvent();
 };
 
 // 백로그 이벤트 - edit 버튼 이벤트

--- a/scripts/initEventListeners.js
+++ b/scripts/initEventListeners.js
@@ -77,7 +77,6 @@ const editBtnEvent = ({ state, finishDateContent, backLogTaskContent, editBtn, i
       if (state.editing) {
         finishDateContent.disabled = true;
         state.editing = false;
-        sortTodos();
       }
       e.target.disabled = true;
       state.title = true;


### PR DESCRIPTION
## 변경 사항 설명
발생하는 오류
- scripts/initEventListeners.js 파일의 initBackLogEvents 함수의 document.addEventListener가 다른 함수를 호출하는 과정에서 호출되어 taskContainer 요소가 중복으로 생성되는 오류.

해결방법
- 무조건 실행되는 document.addEventListener를 별도의 함수(handleOutsideClick)로 분리하여 중복 실행을 막음.

## 관련 이슈
[BUG] #24 

## 체크리스트
- [x] 코드가 TypeScript/ESLint 규칙을 준수합니다
- [x] 필요한 테스트를 추가했습니다
- [x] 모든 테스트가 통과합니다
- [ ] 관련 문서를 업데이트했습니다 (필요한 경우)

## 스크린샷 (UI 변경사항이 있는 경우)
<img width="1446" alt="스크린샷 2025-05-13 오후 3 48 49" src="https://github.com/user-attachments/assets/89e2033e-549d-444e-9398-eb5e8bb2b6e9" />

## 리뷰어를 위한 참고사항
- 해당 PR의 코드를 확인해보시고 테스트 부탁드립니다.
- 위 버그를 해결 후 #23 문제는 taskContainer 요소 밖을 외부 클릭으로 인식해야 되는데 요소 내부에서도 외부 클릭으로 인식되는 문제를 해결해야됩니다.