### PR TITLE
fix : sortTodos 렌더링 오류

### DIFF
--- a/scripts/initEventListeners.js
+++ b/scripts/initEventListeners.js
@@ -316,7 +316,10 @@ const checkboxEvent = ({ div, backlogId, subTask, textEl, checkbox }) => {
 
     const allChecked = backlog.list.every((sub) => sub.check === true);
     backlog.complete = allChecked;
-    if (allChecked) window.dispatchEvent(new CustomEvent("updateChecklist"));
+    if (allChecked) {
+      window.dispatchEvent(new CustomEvent("updateChecklist"));
+      sortTodos();
+    }
     renderInitialSubTasks();
     saveToLocalStorage();
   });
@@ -395,7 +398,6 @@ const initCompletedTaskEvents = ({ item, delBtn }) => {
     completeDelete(item);
     renderCompletedTasks(todos);
   });
-  sortTodos();
 };
 
 // 모달 창 열기 이벤트


### PR DESCRIPTION
## 변경 사항 설명
발생하는 오류
- scripts/initEventListeners.js 파일의 initBackLogEvents 함수의 document.addEventListener가 다른 함수를 호출하는 과정에서 호출되어 taskContainer 요소가 중복으로 생성되는 오류.
- 완료 태스크 처리 후 백로그 태스크 추가 시 날짜 선택 및 저장 오류

결론, 완료 태스크 쪽 todos()로 인한 백로그 중복 렌더링 오류 발생

해결 방법
완료 태스크 쪽 todos() 제거 및 체크 리스트쪽 모두 체크 시 todos() 호출

## 관련 이슈
#24 
#23 

## 체크리스트
- [x] 코드가 TypeScript/ESLint 규칙을 준수합니다
- [x] 필요한 테스트를 추가했습니다
- [x] 모든 테스트가 통과합니다
- [x] 관련 문서를 업데이트했습니다 (필요한 경우)

## 스크린샷 (UI 변경사항이 있는 경우)

## 리뷰어를 위한 참고사항